### PR TITLE
Adding LabVIEW NXG .gitignore template file

### DIFF
--- a/LabVIEWNXG.gitignore
+++ b/LabVIEWNXG.gitignore
@@ -1,0 +1,7 @@
+# caches
+.cache/
+*.lvcompile
+*.lvindexcache
+
+# Default build output directory for packages, executables, etc.
+Builds/


### PR DESCRIPTION

**Reasons for making this change:**

To provide a starting point for .gitignore files for LabVIEW NXG users that use Git. A similar gitignore template exists for LabVIEW in this repo.

**Links to documentation supporting these rule changes:**
The files noted as to be ignored in the template are either meta data produced by the product to optimize performance or build artifacts created by the customer which we recommend aren't to be checked in with source. 

The template corresponds to as the product exists in 3.0 release (LabVIEW NXG 3.0 release). It excludes cache folder and files, and build output directory.

If this is a new template:

 - **Link to application or project’s homepage**: http://www.ni.com/en-us/shop/labview/labview-nxg.html
